### PR TITLE
use opensourced swagger core and parser dependencies

### DIFF
--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/DefaultCodegenTest.java
@@ -402,7 +402,7 @@ public class DefaultCodegenTest {
         CodegenParameter codegenParameter2 = CodegenModelFactory.newInstance(CodegenModelType.PARAMETER);
         codegen.setParameterExampleValue(codegenParameter2, operation2.getParameters().get(0));
 
-        Assert.assertEquals(codegenParameter2.example, "example3: parameter value");
+        Assert.assertEquals(codegenParameter2.example, "An example3 value");
     }
 
     @Test

--- a/modules/openapi-generator/src/test/java/org/openapitools/codegen/serializer/SerializerUtilsTest.java
+++ b/modules/openapi-generator/src/test/java/org/openapitools/codegen/serializer/SerializerUtilsTest.java
@@ -77,7 +77,7 @@ public class SerializerUtilsTest {
                "      description: Some description\n" +
                "      operationId: pingOp\n" +
                "      responses:\n" +
-               "        200:\n" +
+               "        \"200\":\n" +
                "          description: Ok\n" +
                "components:\n" +
                "  schemas:\n" +
@@ -116,7 +116,7 @@ public class SerializerUtilsTest {
                 "      description: Some description\n" +
                 "      operationId: pingOp\n" +
                 "      responses:\n" +
-                "        200:\n" +
+                "        \"200\":\n" +
                 "          description: Ok\n";
         assertEquals(content, expected);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1331,6 +1331,12 @@
                 <artifactId>testng</artifactId>
                 <version>${testng-version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>snakeyaml</artifactId>
+                        <groupId>org.yaml</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.jmockit</groupId>
@@ -1356,8 +1362,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <swagger-parser-version>2.0.8-ibm4</swagger-parser-version>
-        <swagger-core-version>2.0.7-ibm3</swagger-core-version>
+        <swagger-parser-version>2.0.25</swagger-parser-version>
+        <swagger-core-version>2.1.9</swagger-core-version>
         <scala-version>2.11.1</scala-version>
         <felix-version>3.3.1</felix-version>
         <commons-io-version>2.4</commons-io-version>


### PR DESCRIPTION
This PR uses the most recent releases of the Swagger Parser and Swagger Core.  A few modifications were needed to the dependencies to get this to work, but there are also two convention differences classified as bugs that have changed in the underlying dependencies.

1. HTTP codes are now [strings instead of integers](https://github.com/OpenAPITools/openapi-generator/pull/4915#discussion_r365146355), in release 2.1+ of Swagger Core.
1. If "examples" and "example" both defined, Swagger Parser [ignores "example"](https://github.com/swagger-api/swagger-parser/issues/1483) in versions 2.0.24+.

